### PR TITLE
Upgrade to JDK 11 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Version: 0.1
-FROM adoptopenjdk/openjdk9-openj9:latest
+FROM adoptopenjdk/openjdk11-openj9:latest
 MAINTAINER Jakub Jozwicki jakub.jozwicki@gmail.com
 COPY target/TimeZoneService-0.0.1-SNAPSHOT.jar /tmp/
 COPY src/main/resources/application.properties /tmp/


### PR DESCRIPTION
Users will almost certainly benefit from updating to the latest LTS major version of Java. This upgrade adds cgroup awareness, an essential feature for preventing OOM kills on a container platform; generally improves performance; and is much less likely to break existing code than the migration from JDK 8 to 9 did.